### PR TITLE
🐛 Stricter eLife heuristic (`reviewed-preprints` + digits requirement)

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -92,6 +92,8 @@ describe('normalize', () => {
 describe('external DOI links', () => {
   test.each([
     ['elife', 'https://elifesciences.org/articles/59045', '10.7554/eLife.59045'],
+    ['elife', 'https://elifesciences.org/reviewed-preprints/103597', '10.7554/eLife.103597'],
+    ['elife', 'https://elifesciences.org/articles/short-report', undefined],
     [
       'wiley',
       'https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022GC010600',
@@ -113,7 +115,7 @@ describe('external DOI links', () => {
     ],
   ])('Test %s (%s) <%s>', (_, url, doiString) => {
     expect(doi.normalize(url)).toBe(doiString);
-    expect(doi.validate(url)).toBe(true);
+    expect(doi.validate(url)).toBe(doiString ? true : false);
     expect(doi.validate(url, { strict: true })).toBe(false);
   });
 });

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -16,10 +16,13 @@ const doiOrg: Resolver = {
 
 const elife: Resolver = {
   test(url) {
-    return url.hostname.endsWith('elifesciences.org') && /^\/articles\/\d+$/.test(url.pathname);
+    return (
+      url.hostname.endsWith('elifesciences.org') &&
+      /^\/(?:articles|reviewed-preprints)\/\d+$/.test(url.pathname)
+    );
   },
   parse(url) {
-    return `10.7554/eLife.${url.pathname.replace('/articles/', '')}`;
+    return `10.7554/eLife.${url.pathname.replace(/^\/(?:articles|reviewed-preprints)\//, '')}`;
   },
 };
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -16,7 +16,7 @@ const doiOrg: Resolver = {
 
 const elife: Resolver = {
   test(url) {
-    return url.hostname.endsWith('elifesciences.org') && url.pathname.startsWith('/articles/');
+    return url.hostname.endsWith('elifesciences.org') && /^\/articles\/\d+$/.test(url.pathname);
   },
   parse(url) {
     return `10.7554/eLife.${url.pathname.replace('/articles/', '')}`;


### PR DESCRIPTION
This PR increases the eLife heuristic strictness, to avoid false positives for https://elifesciences.org/articles/short-report

c.f. https://github.com/jupyter-book/mystmd/issues/1336#issuecomment-2695939029
